### PR TITLE
Update Moq version in test project

### DIFF
--- a/SmartPortaria.Tests/SmartPortaria.Tests.csproj
+++ b/SmartPortaria.Tests/SmartPortaria.Tests.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- bump Moq reference in the test project to 4.20.72

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cfd067a4832f8a8d9374bf6bdb38