### PR TITLE
Fix test csproj compile item

### DIFF
--- a/SmartPortaria.Tests/SmartPortaria.Tests.csproj
+++ b/SmartPortaria.Tests/SmartPortaria.Tests.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <Compile Include="../Controllers/LoginController.cs" Link="Controllers/LoginController.cs" />
     <Compile Include="../Controllers/UsuarioController.cs" Link="Controllers/UsuarioController.cs" />
-    <Compile Include="Stubs/*.cs" />
+    <!-- <Compile Include="Stubs/*.cs" /> -->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- comment out Stubs compile inclusion in test project

## Testing
- `dotnet test SmartPortaria.Tests/SmartPortaria.Tests.csproj` *(fails: NETSDK1045 - current .NET SDK does not support targeting .NET 10.0)*

------
https://chatgpt.com/codex/tasks/task_e_6840d032549c832f8e9da69c53f5835c